### PR TITLE
chore(go): use go 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* chore(go): use go 1.17
+
 ## 1.3.0
 
 * Merge with upstream

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Scalingo/go-plugins-helpers
 
-go 1.16
+go 1.17


### PR DESCRIPTION
The fix for CVE-2022-29526 is only available in Go 1.17 and 1.18.