### PR TITLE
feat: add error and content type middlewares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* feat: add error and content type middlewares
+
 ## 1.4.0
 
 * chore(go): use go 1.23.5

--- a/ipam/api.go
+++ b/ipam/api.go
@@ -82,16 +82,6 @@ type ReleaseAddressRequest struct {
 	Address string
 }
 
-// ErrorResponse is a formatted error message that libnetwork can understand
-type ErrorResponse struct {
-	Err string
-}
-
-// NewErrorResponse creates an ErrorResponse with the provided message
-func NewErrorResponse(msg string) *ErrorResponse {
-	return &ErrorResponse{Err: msg}
-}
-
 // Handler forwards requests and responses between the docker daemon and the plugin.
 type Handler struct {
 	ipam Ipam
@@ -115,19 +105,17 @@ func (h *Handler) initMux() {
 	h.HandleFunc(capabilitiesPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
 		res, err := h.ipam.GetCapabilities(r.Context())
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, res, false)
+		sdk.EncodeResponse(w, res)
 		return nil
 	})
 	h.HandleFunc(addressSpacesPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
 		res, err := h.ipam.GetDefaultAddressSpaces(r.Context())
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, res, false)
+		sdk.EncodeResponse(w, res)
 		return nil
 	})
 	h.HandleFunc(requestPoolPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -143,10 +131,9 @@ func (h *Handler) initMux() {
 		}))
 		res, err := h.ipam.RequestPool(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, res, false)
+		sdk.EncodeResponse(w, res)
 		return nil
 	})
 	h.HandleFunc(releasePoolPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -160,10 +147,9 @@ func (h *Handler) initMux() {
 		}))
 		err = h.ipam.ReleasePool(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, struct{}{}, false)
+		sdk.EncodeResponse(w, struct{}{})
 		return nil
 	})
 	h.HandleFunc(requestAddressPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -178,10 +164,9 @@ func (h *Handler) initMux() {
 		}))
 		res, err := h.ipam.RequestAddress(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, res, false)
+		sdk.EncodeResponse(w, res)
 		return nil
 	})
 	h.HandleFunc(releaseAddressPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -196,10 +181,9 @@ func (h *Handler) initMux() {
 		}))
 		err = h.ipam.ReleaseAddress(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, struct{}{}, false)
+		sdk.EncodeResponse(w, struct{}{})
 		return nil
 	})
 }

--- a/network/api.go
+++ b/network/api.go
@@ -179,11 +179,6 @@ type LeaveRequest struct {
 	EndpointID string
 }
 
-// ErrorResponse is a formatted error message that libnetwork can understand
-type ErrorResponse struct {
-	Err string
-}
-
 // DiscoveryNotification is sent by the daemon when a new discovery event occurs
 type DiscoveryNotification struct {
 	DiscoveryType int
@@ -203,11 +198,6 @@ type ProgramExternalConnectivityRequest struct {
 type RevokeExternalConnectivityRequest struct {
 	NetworkID  string
 	EndpointID string
-}
-
-// NewErrorResponse creates an ErrorResponse with the provided message
-func NewErrorResponse(msg string) *ErrorResponse {
-	return &ErrorResponse{Err: msg}
 }
 
 // Handler forwards requests and responses between the docker daemon and the plugin.
@@ -233,15 +223,12 @@ func (h *Handler) initMux() {
 	h.HandleFunc(capabilitiesPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
 		res, err := h.driver.GetCapabilities(r.Context())
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
 		if res == nil {
-			err := errors.New("Network driver must implement GetCapabilities")
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
-			return err
+			return errors.New("Network driver must implement GetCapabilities")
 		}
-		sdk.EncodeResponse(w, res, false)
+		sdk.EncodeResponse(w, res)
 		return nil
 	})
 	h.HandleFunc(createNetworkPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -255,10 +242,9 @@ func (h *Handler) initMux() {
 		}))
 		err = h.driver.CreateNetwork(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, struct{}{}, false)
+		sdk.EncodeResponse(w, struct{}{})
 		return nil
 	})
 	h.HandleFunc(allocateNetworkPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -272,10 +258,9 @@ func (h *Handler) initMux() {
 		}))
 		res, err := h.driver.AllocateNetwork(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, res, false)
+		sdk.EncodeResponse(w, res)
 		return nil
 	})
 	h.HandleFunc(deleteNetworkPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -289,10 +274,9 @@ func (h *Handler) initMux() {
 		}))
 		err = h.driver.DeleteNetwork(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, struct{}{}, false)
+		sdk.EncodeResponse(w, struct{}{})
 		return nil
 	})
 	h.HandleFunc(freeNetworkPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -306,10 +290,9 @@ func (h *Handler) initMux() {
 		}))
 		err = h.driver.FreeNetwork(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, struct{}{}, false)
+		sdk.EncodeResponse(w, struct{}{})
 		return nil
 	})
 	h.HandleFunc(createEndpointPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -324,10 +307,9 @@ func (h *Handler) initMux() {
 		}))
 		res, err := h.driver.CreateEndpoint(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, res, false)
+		sdk.EncodeResponse(w, res)
 		return nil
 	})
 	h.HandleFunc(deleteEndpointPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -342,10 +324,9 @@ func (h *Handler) initMux() {
 		}))
 		err = h.driver.DeleteEndpoint(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, struct{}{}, false)
+		sdk.EncodeResponse(w, struct{}{})
 		return nil
 	})
 	h.HandleFunc(endpointInfoPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -360,10 +341,9 @@ func (h *Handler) initMux() {
 		}))
 		res, err := h.driver.EndpointInfo(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, res, false)
+		sdk.EncodeResponse(w, res)
 		return nil
 	})
 	h.HandleFunc(joinPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -378,10 +358,9 @@ func (h *Handler) initMux() {
 		}))
 		res, err := h.driver.Join(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, res, false)
+		sdk.EncodeResponse(w, res)
 		return nil
 	})
 	h.HandleFunc(leavePath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -396,10 +375,9 @@ func (h *Handler) initMux() {
 		}))
 		err = h.driver.Leave(ctx, req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, struct{}{}, false)
+		sdk.EncodeResponse(w, struct{}{})
 		return nil
 	})
 	h.HandleFunc(discoverNewPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -410,10 +388,9 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.DiscoverNew(r.Context(), req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, struct{}{}, false)
+		sdk.EncodeResponse(w, struct{}{})
 		return nil
 	})
 	h.HandleFunc(discoverDeletePath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -424,10 +401,9 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.DiscoverDelete(r.Context(), req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, struct{}{}, false)
+		sdk.EncodeResponse(w, struct{}{})
 		return nil
 	})
 	h.HandleFunc(programExtConnPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -438,10 +414,9 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.ProgramExternalConnectivity(r.Context(), req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, struct{}{}, false)
+		sdk.EncodeResponse(w, struct{}{})
 		return nil
 	})
 	h.HandleFunc(revokeExtConnPath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
@@ -452,10 +427,9 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.RevokeExternalConnectivity(r.Context(), req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return err
 		}
-		sdk.EncodeResponse(w, struct{}{}, false)
+		sdk.EncodeResponse(w, struct{}{})
 		return nil
 	})
 }

--- a/sdk/encoder.go
+++ b/sdk/encoder.go
@@ -19,17 +19,12 @@ func DecodeRequest(w http.ResponseWriter, r *http.Request, req interface{}) (err
 }
 
 // EncodeResponse encodes the given structure into an http response.
-func EncodeResponse(w http.ResponseWriter, res interface{}, err bool) {
-	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
-	if err {
-		w.WriteHeader(http.StatusInternalServerError)
-	}
+func EncodeResponse(w http.ResponseWriter, res interface{}) {
 	json.NewEncoder(w).Encode(res)
 }
 
 // StreamResponse streams a response object to the client
 func StreamResponse(w http.ResponseWriter, data io.ReadCloser) {
-	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
 	if _, err := copyBuf(w, data); err != nil {
 		fmt.Printf("ERROR in stream: %v\n", err)
 	}

--- a/sdk/middlewares.go
+++ b/sdk/middlewares.go
@@ -1,0 +1,39 @@
+package sdk
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Scalingo/go-handlers"
+)
+
+// contentTypeMiddleware sets the HTTP header `Content-Type` to the content type accepted and sent by Docker plugins
+var contentTypeMiddleware = handlers.MiddlewareFunc(func(handler handlers.HandlerFunc) handlers.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+		w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+		return handler(w, r, vars)
+	}
+})
+
+// ErrorResponse is a formatted error message that Docker can understand
+type ErrorResponse struct {
+	Err string
+}
+
+// NewErrorResponse creates an ErrorResponse with the provided error
+func NewErrorResponse(err error) ErrorResponse {
+	return ErrorResponse{Err: err.Error()}
+}
+
+// errorMiddleware encodes in JSON the error returned by the handler to the HTTP request body
+var errorMiddleware = handlers.MiddlewareFunc(func(handler handlers.HandlerFunc) handlers.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+		err := handler(w, r, vars)
+		if err != nil {
+			json.NewEncoder(w).Encode(NewErrorResponse(err))
+			return err
+		}
+
+		return nil
+	}
+})


### PR DESCRIPTION
The current implementation of the error middleware does not work. It prevents a service using this lib to add a middleware to catch specific errors and return a specific status code. Hence I'm adding an error middleware specific to this lib as Docker needs us to encode errors in a specific format.

I'm also exposing the `go-handlers.Router.Use` function as it could be really useful for services using this lib.

I'm also adding a content type middleware to set the `Content-Type` header of all requests to what is expected from Docker plugins.

I tested the content of this PR in https://github.com/Scalingo/swan-agent/pull/293 and it works.


Related to [STORY-270](https://www.notion.so/Endpoint-creation-180e678b3b9741929c4626288b49b268?pvs=8&n=github_linkback)