### PR TITLE
feat(sdk): introduce a `Manifest` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To Be Released
 
 * feat: add error and content type middlewares
+* feat(sdk): introduce a `Manifest` type
 
 ## 1.4.0
 

--- a/authorization/api.go
+++ b/authorization/api.go
@@ -18,12 +18,11 @@ const (
 	// AuthZApiResponse is the url for daemon response authorization
 	AuthZApiResponse = "AuthZPlugin.AuthZRes"
 
-	// AuthZApiImplements is the name of the interface all AuthZ plugins implement
-	AuthZApiImplements = "authz"
+	// ImplementationName is the name of the interface all AuthZ plugins implement
+	ImplementationName sdk.DriverImplementationName = "authz"
 
-	manifest = `{"Implements": ["` + AuthZApiImplements + `"]}`
-	reqPath  = "/" + AuthZApiRequest
-	resPath  = "/" + AuthZApiResponse
+	reqPath = "/" + AuthZApiRequest
+	resPath = "/" + AuthZApiResponse
 )
 
 // PeerCertificate is a wrapper around x509.Certificate which provides a sane
@@ -110,7 +109,9 @@ type Handler struct {
 
 // NewHandler initializes the request handler with a plugin implementation.
 func NewHandler(logger logrus.FieldLogger, plugin Plugin) *Handler {
-	h := &Handler{plugin, sdk.NewHandler(logger, manifest)}
+	h := &Handler{plugin, sdk.NewHandler(logger, sdk.Manifest{
+		Implements: []sdk.DriverImplementationName{ImplementationName},
+	})}
 	h.initMux()
 	return h
 }

--- a/authorization/api_test.go
+++ b/authorization/api_test.go
@@ -43,6 +43,8 @@ func (p *TestPlugin) AuthZRes(r Request) Response {
 }
 
 func TestActivate(t *testing.T) {
+	const expectedManifest = string(`{"Implements":["` + ImplementationName + `"]}`)
+
 	response, err := http.Get("http://localhost:32456/Plugin.Activate")
 	if err != nil {
 		t.Fatal(err)
@@ -54,9 +56,10 @@ func TestActivate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	bodyStr := strings.TrimSpace(string(body))
 
-	if string(body) != manifest+"\n" {
-		t.Fatalf("Expected %s, got %s\n", manifest+"\n", string(body))
+	if bodyStr != expectedManifest {
+		t.Fatalf("Expected '%s', got '%s'\n", expectedManifest, bodyStr)
 	}
 }
 

--- a/ipam/api.go
+++ b/ipam/api.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	manifest = `{"Implements": ["IpamDriver"]}`
+	// ImplementationName is the name of the interface all IPAM plugins implement
+	ImplementationName sdk.DriverImplementationName = "IpamDriver"
 
 	capabilitiesPath   = "/IpamDriver.GetCapabilities"
 	addressSpacesPath  = "/IpamDriver.GetDefaultAddressSpaces"
@@ -90,7 +91,9 @@ type Handler struct {
 
 // NewHandler initializes the request handler with a driver implementation.
 func NewHandler(logger logrus.FieldLogger, driver Ipam) *Handler {
-	h := &Handler{driver, sdk.NewHandler(logger, manifest)}
+	h := &Handler{driver, sdk.NewHandler(logger, sdk.Manifest{
+		Implements: []sdk.DriverImplementationName{ImplementationName},
+	})}
 	h.initMux()
 	return h
 }

--- a/network/api.go
+++ b/network/api.go
@@ -12,7 +12,9 @@ import (
 )
 
 const (
-	manifest = `{"Implements": ["NetworkDriver"]}`
+	// ImplementationName is the name of the interface all network plugins implement
+	ImplementationName sdk.DriverImplementationName = "NetworkDriver"
+
 	// LocalScope is the correct scope response for a local scope driver
 	LocalScope = `local`
 	// GlobalScope is the correct scope response for a global scope driver
@@ -208,7 +210,9 @@ type Handler struct {
 
 // NewHandler initializes the request handler with a driver implementation.
 func NewHandler(logger logrus.FieldLogger, driver Driver) *Handler {
-	h := &Handler{driver, sdk.NewHandler(logger, manifest)}
+	h := &Handler{driver, sdk.NewHandler(logger, sdk.Manifest{
+		Implements: []sdk.DriverImplementationName{ImplementationName},
+	})}
 	h.initMux()
 	return h
 }

--- a/network/api_test.go
+++ b/network/api_test.go
@@ -153,15 +153,21 @@ func TestMain(m *testing.M) {
 }
 
 func TestActivate(t *testing.T) {
+	const expectedManifest = string(`{"Implements":["` + ImplementationName + `"]}`)
+
 	response, err := http.Get("http://localhost:32234/Plugin.Activate")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer response.Body.Close()
 	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodyStr := strings.TrimSpace(string(body))
 
-	if string(body) != manifest+"\n" {
-		t.Fatalf("Expected %s, got %s\n", manifest+"\n", string(body))
+	if bodyStr != expectedManifest {
+		t.Fatalf("Expected '%s', got '%s'\n", expectedManifest, bodyStr)
 	}
 }
 

--- a/sdk/handler.go
+++ b/sdk/handler.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -20,16 +19,22 @@ type Handler struct {
 	mux *handlers.Router
 }
 
+type DriverImplementationName string
+
+type Manifest struct {
+	Implements []DriverImplementationName `json:"Implements"`
+}
+
 // NewHandler creates a new Handler with an http mux.
 // It configures a single default route for the plugin activation and adds a bunch of middlewares.
-func NewHandler(logger logrus.FieldLogger, manifest string) Handler {
+func NewHandler(logger logrus.FieldLogger, manifest Manifest) Handler {
 	mux := handlers.NewRouter(logger)
 	mux.Use(handlers.ErrorMiddleware)
 	mux.Use(errorMiddleware)
 	mux.Use(contentTypeMiddleware)
 
 	mux.HandleFunc(activatePath, func(w http.ResponseWriter, r *http.Request, p map[string]string) error {
-		fmt.Fprintln(w, manifest)
+		EncodeResponse(w, manifest)
 		return nil
 	})
 


### PR DESCRIPTION
Currently we need to pass a string and I find this ugly. For example:

```go
const manifest = `{"Implements": ["NetworkDriver", "IpamDriver"]}`
dockerPluginHandler := dockerpluginssdk.NewHandler(log, manifest)
```

This is too error-prone in my opinion.

Introduction of this PR would lead to a new major version (v2). This lib is only used in SAND and SWAN. If we don't upgrade to v2 in SAND, then there is no impact there. And we just need to use this version in SWAN.

Related to [STORY-270](https://www.notion.so/Endpoint-creation-180e678b3b9741929c4626288b49b268?pvs=8&n=github_linkback)