### PR TITLE
feat(network): add missing fields to network and IPAM `CapabilitiesResponse`

### DIFF
--- a/authorization/api.go
+++ b/authorization/api.go
@@ -141,7 +141,7 @@ func (h *Handler) handle(name string, actionCall actionHandler) {
 
 		res := actionCall(req)
 
-		sdk.EncodeResponse(w, res, res.Err != "")
+		sdk.EncodeResponse(w, res)
 
 		return nil
 	})

--- a/ipam/api.go
+++ b/ipam/api.go
@@ -34,7 +34,8 @@ type Ipam interface {
 
 // CapabilitiesResponse returns whether or not this IPAM required pre-made MAC
 type CapabilitiesResponse struct {
-	RequiresMACAddress bool
+	RequiresMACAddress    bool
+	RequiresRequestReplay bool
 }
 
 // AddressSpacesResponse returns the default local and global address space names for this IPAM

--- a/network/api.go
+++ b/network/api.go
@@ -15,11 +15,6 @@ const (
 	// ImplementationName is the name of the interface all network plugins implement
 	ImplementationName sdk.DriverImplementationName = "NetworkDriver"
 
-	// LocalScope is the correct scope response for a local scope driver
-	LocalScope = `local`
-	// GlobalScope is the correct scope response for a global scope driver
-	GlobalScope = `global`
-
 	capabilitiesPath    = "/NetworkDriver.GetCapabilities"
 	allocateNetworkPath = "/NetworkDriver.AllocateNetwork"
 	freeNetworkPath     = "/NetworkDriver.FreeNetwork"
@@ -38,6 +33,8 @@ const (
 
 // Driver represent the interface a driver must fulfill.
 type Driver interface {
+	// GetCapabilities returns the driver capabilities
+	// https://github.com/moby/moby/blob/master/libnetwork/docs/remote.md#set-capability
 	GetCapabilities(context.Context) (*CapabilitiesResponse, error)
 	CreateNetwork(context.Context, *CreateNetworkRequest) error
 	AllocateNetwork(context.Context, *AllocateNetworkRequest) (*AllocateNetworkResponse, error)
@@ -54,10 +51,20 @@ type Driver interface {
 	RevokeExternalConnectivity(context.Context, *RevokeExternalConnectivityRequest) error
 }
 
+type CapabilitiesResponseScope string
+
+const (
+	// LocalScope is the correct scope response for a local scope driver
+	LocalScope CapabilitiesResponseScope = "local"
+	// GlobalScope is the correct scope response for a global scope driver
+	GlobalScope CapabilitiesResponseScope = "global"
+)
+
 // CapabilitiesResponse returns whether or not this network is global or local
 type CapabilitiesResponse struct {
-	Scope             string
-	ConnectivityScope string
+	Scope             CapabilitiesResponseScope
+	ConnectivityScope CapabilitiesResponseScope
+	GwAllocChecker    bool
 }
 
 // AllocateNetworkRequest requests allocation of new network by manager

--- a/network/api_test.go
+++ b/network/api_test.go
@@ -179,7 +179,7 @@ func TestCapabilitiesExchange(t *testing.T) {
 	defer response.Body.Close()
 	body, err := io.ReadAll(response.Body)
 
-	expected := `{"Scope":"local","ConnectivityScope":"global"}`
+	expected := `{"Scope":"local","ConnectivityScope":"global","GwAllocChecker":false}`
 	if string(body) != expected+"\n" {
 		t.Fatalf("Expected %s, got %s\n", expected+"\n", string(body))
 	}


### PR DESCRIPTION
The libnetwork API apparently changed:
- The network driver capabilities can now take a `GwAllocChecker`: https://github.com/moby/moby/blob/af898abe44662d9554fb15ee4d4a7307f1b8e315/libnetwork/docs/remote.md#set-capability
- The IPAM driver capabilities can now take a `RequiresRequestReplay`: https://github.com/moby/moby/blob/af898abe44662d9554fb15ee4d4a7307f1b8e315/libnetwork/docs/ipam.md#getcapabilities


Related to [STORY-308](https://www.notion.so/Plugin-specs-creation-bce319f176df48ba8356f6ffc15c4c1f?pvs=8&n=github_linkback)