### PR TITLE
feat(network): add type `CreateNetworkRequestOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## To Be Released
 
-* v2.0.0
+* fix: makes the CI pass
+* feat(network): add missing fields to network and IPAM `CapabilitiesResponse`
+* feat(network): add type `CreateNetworkRequestOptions`
+
+## v2.0.0
 
 * feat: add error and content type middlewares
 * feat(sdk): introduce a `Manifest` type

--- a/network/api.go
+++ b/network/api.go
@@ -96,9 +96,15 @@ type FreeNetworkRequest struct {
 // CreateNetworkRequest is sent by the daemon when a network needs to be created
 type CreateNetworkRequest struct {
 	NetworkID string
-	Options   map[string]interface{}
+	Options   CreateNetworkRequestOptions
 	IPv4Data  []*IPAMData
 	IPv6Data  []*IPAMData
+}
+
+type CreateNetworkRequestOptions struct {
+	Generic    map[string]string `json:"com.docker.network.generic"`
+	EnableIPv4 bool              `json:"com.docker.network.enable_ipv4"`
+	EnableIPv6 bool              `json:"com.docker.network.enable_ipv6"`
 }
 
 // IPAMData contains IPv4 or IPv6 addressing information


### PR DESCRIPTION
Without this, it would require to make a lot of casting like in SAND but I find it suboptimal. Here is the SAND code:

https://github.com/Scalingo/sand/blob/bb2e01e837e178345c75e21d09a37f36c1d32e1c/integrations/docker/driver_network.go#L33-L41

I tested this PR in SWAN and I find the code better: https://github.com/Scalingo/swan-agent/pull/333

Related to [STORY-1530](https://www.notion.so/FEAT-Network-CRUD-1a0f536d89bf80aeb44bf560fa718547?pvs=8&n=github_linkback)

