### PR TITLE
feat(ipam): add type `RequestAddressRequestOptions`

### DIFF
--- a/ipam/api.go
+++ b/ipam/api.go
@@ -69,8 +69,18 @@ type ReleasePoolRequest struct {
 type RequestAddressRequest struct {
 	PoolID  string
 	Address string
-	Options map[string]string
+	Options RequestAddressRequestOptions
 }
+
+type RequestAddressRequestOptions struct {
+	RequestAddressType RequestAddressType `json:"RequestAddressType"`
+}
+
+type RequestAddressType string
+
+const (
+	RequestAddressTypeGateway RequestAddressType = "com.docker.network.gateway"
+)
 
 // RequestAddressResponse is formed with allocated address by IPAM
 type RequestAddressResponse struct {


### PR DESCRIPTION
We did the same for `CreateNetworkRequestOptions` in #64. It makes the implementation cleaner.

Related to [STORY-277](https://www.notion.so/IPAM-driver-17450b6de5b9493a903aeb1c6134825c)

Tested in https://github.com/Scalingo/swan-agent/pull/357