### PR TITLE
Fix VUL-224: Change MarshalJSON to use value receiver

### DIFF
--- a/authorization/api.go
+++ b/authorization/api.go
@@ -30,7 +30,7 @@ const (
 type PeerCertificate x509.Certificate
 
 // MarshalJSON returns the JSON encoded pem bytes of a PeerCertificate.
-func (pc *PeerCertificate) MarshalJSON() ([]byte, error) {
+func (pc PeerCertificate) MarshalJSON() ([]byte, error) {
 	b := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: pc.Raw})
 	return json.Marshal(b)
 }


### PR DESCRIPTION
## Summary
• Changed PeerCertificate.MarshalJSON from pointer receiver to value receiver to avoid surprising behavior with JSON marshaling as described in golang/go#22967